### PR TITLE
Кастомизация клиента.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,10 @@ name: ci
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
     branches:
-      - main
+      - master
 
 jobs:
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: v1.32

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 *.dll
 *.so
 *.dylib
-
+.idea
 # Test binary, built with `go test -c`
 *.test
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,22 @@
+run:
+  tests: false
+  skip-dirs:
+    - examples
+  skip-files:
+    - rest_domain.go
+    - streaming_client.go
+    - streaming_domain.go
+
+linters-settings:
+  lll:
+    line-length: 190
+  maligned:
+    suggest-new: true
+
+linters:
+  enable-all: true
+  disable:
+    - wsl
+    - exhaustivestruct
+  fast: false
+

--- a/error.go
+++ b/error.go
@@ -1,0 +1,32 @@
+package sdk
+
+import "fmt"
+
+// TradingError contains error info from tinkoff invest.
+type TradingError struct {
+	TrackingID string `json:"trackingId"`
+	Status     string `json:"status"`
+	Hint       string
+	Payload    struct {
+		Message string `json:"message"`
+		Code    string `json:"code"`
+	} `json:"payload"`
+}
+
+// Error for implements error.
+func (t TradingError) Error() string {
+	return fmt.Sprintf(
+		"TrackingID: %s, Status: %s, Message: %s, Code: %s, Hint: %s",
+		t.TrackingID, t.Status, t.Payload.Message, t.Payload.Code, t.Hint,
+	)
+}
+
+// NotEnoughBalance for check error.
+func (t TradingError) NotEnoughBalance() bool {
+	return t.Payload.Code == "NOT_ENOUGH_BALANCE"
+}
+
+// InvalidTokenSpace for check error.
+func (t TradingError) InvalidTokenSpace() bool {
+	return t.Payload.Message == "Invalid token scopes"
+}

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/TinkoffCreditSystems/invest-openapi-go-sdk
 
-go 1.12
+go 1.15
 
 require (
-	github.com/gorilla/websocket v1.4.1
+	github.com/gorilla/websocket v1.4.2
 	github.com/pkg/errors v0.9.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/gorilla/websocket v1.4.1 h1:q7AeDBpnBk8AogcD4DSag/Ukw/KV+YhzLj2bP5HvKCM=
-github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
+github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/http_client.go
+++ b/http_client.go
@@ -1,0 +1,92 @@
+package sdk
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+var _ HTTP = &defaultHTTP{}
+
+type (
+	// HTTP interface for change http client.
+	HTTP interface {
+		Get(ctx context.Context, url string, header http.Header, unmarshal interface{}) error
+		Post(ctx context.Context, url string, header http.Header, body []byte, unmarshal interface{}) error
+	}
+
+	defaultHTTP struct {
+		client *http.Client
+	}
+)
+
+// Post for implements HTTP.
+func (c *defaultHTTP) Post(ctx context.Context, url string, header http.Header, body []byte, unmarshal interface{}) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(body))
+	if err != nil {
+		return fmt.Errorf("build new request: %w", err)
+	}
+	req.Header = header
+
+	resp, err := c.do(req)
+	if err != nil {
+		return fmt.Errorf("http do: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if unmarshal != nil {
+		err = json.NewDecoder(resp.Body).Decode(unmarshal)
+		if err != nil {
+			return fmt.Errorf("decode json: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// Get for implements HTTP.
+func (c *defaultHTTP) Get(ctx context.Context, url string, header http.Header, unmarshal interface{}) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("build new request: %w", err)
+	}
+	req.Header = header
+
+	resp, err := c.do(req)
+	if err != nil {
+		return fmt.Errorf("http do: %w", err)
+	}
+	defer resp.Body.Close()
+
+	err = json.NewDecoder(resp.Body).Decode(unmarshal)
+	if err != nil {
+		return fmt.Errorf("decode json: %w", err)
+	}
+
+	return nil
+}
+
+func (c *defaultHTTP) do(req *http.Request) (*http.Response, error) {
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("http client do: %w", err)
+	}
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+	case http.StatusNotFound:
+		return nil, ErrNotFound
+	default:
+		tradingError := TradingError{}
+		err := json.NewDecoder(resp.Body).Decode(&tradingError)
+		if err != nil {
+			return nil, fmt.Errorf("json decode error: %w", err)
+		}
+
+		return nil, tradingError
+	}
+
+	return resp, nil
+}

--- a/rest_sandbox_client.go
+++ b/rest_sandbox_client.go
@@ -2,7 +2,6 @@ package sdk
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 )
 
@@ -33,14 +32,9 @@ func (c *SandboxRestClient) Register(ctx context.Context, accountType AccountTyp
 		AccountType AccountType `json:"brokerAccountType"`
 	}{AccountType: accountType}
 
-	buf, err := json.Marshal(payload)
+	err := c.provider.Post(ctx, path, c.token, payload, &response)
 	if err != nil {
-		return Account{}, fmt.Errorf("json marshal payload: %w", err)
-	}
-
-	err = c.http.Post(ctx, path, c.header(c.token), buf, &response)
-	if err != nil {
-		return Account{}, fmt.Errorf("http post: %w", err)
+		return Account{}, fmt.Errorf("provider post: %w", err)
 	}
 
 	return response.Payload, nil
@@ -54,9 +48,9 @@ func (c *SandboxRestClient) Clear(ctx context.Context, accountID string) error {
 		path += "?brokerAccountId=" + accountID
 	}
 
-	err := c.http.Post(ctx, path, c.header(c.token), nil, nil)
+	err := c.provider.Post(ctx, path, c.token, nil, nil)
 	if err != nil {
-		return fmt.Errorf("http post: %w", err)
+		return fmt.Errorf("provider post: %w", err)
 	}
 
 	return nil
@@ -70,9 +64,9 @@ func (c *SandboxRestClient) Remove(ctx context.Context, accountID string) error 
 		path += "?brokerAccountId=" + accountID
 	}
 
-	err := c.http.Post(ctx, path, c.header(c.token), nil, nil)
+	err := c.provider.Post(ctx, path, c.token, nil, nil)
 	if err != nil {
-		return fmt.Errorf("http post: %w", err)
+		return fmt.Errorf("provider post: %w", err)
 	}
 
 	return nil
@@ -92,14 +86,9 @@ func (c *SandboxRestClient) SetCurrencyBalance(ctx context.Context, accountID st
 		payload.AccountID = accountID
 	}
 
-	buf, err := json.Marshal(payload)
+	err := c.provider.Post(ctx, path, c.token, payload, nil)
 	if err != nil {
-		return fmt.Errorf("json marshal payload: %w", err)
-	}
-
-	err = c.http.Post(ctx, path, c.header(c.token), buf, nil)
-	if err != nil {
-		return fmt.Errorf("http post: %w", err)
+		return fmt.Errorf("provider post: %w", err)
 	}
 
 	return nil
@@ -119,14 +108,9 @@ func (c *SandboxRestClient) SetPositionsBalance(ctx context.Context, accountID, 
 		payload.AccountID = accountID
 	}
 
-	buf, err := json.Marshal(payload)
+	err := c.provider.Post(ctx, path, c.token, payload, nil)
 	if err != nil {
-		return fmt.Errorf("json marshal payload: %w", err)
-	}
-
-	err = c.http.Post(ctx, path, c.header(c.token), buf, nil)
-	if err != nil {
-		return fmt.Errorf("http post: %w", err)
+		return fmt.Errorf("provider post: %w", err)
 	}
 
 	return nil

--- a/streaming_client.go
+++ b/streaming_client.go
@@ -123,7 +123,6 @@ func (c *StreamingClient) UnsubscribeCandle(figi string, interval CandleInterval
 	return nil
 }
 
-var ErrDepth = errors.Errorf("invalid depth. Should be in interval 0 < x <= %d", MaxOrderbookDepth)
 
 func (c *StreamingClient) SubscribeOrderbook(figi string, depth int, requestID string) error {
 	if depth < 1 || depth > MaxOrderbookDepth {


### PR DESCRIPTION
Решил помочь в сопровождении библиотеки

1) Добавил фукнциональные параметры для билда клиента, дабы не иметь N конструкторов под разные параметры (также указал, что второй конструктор Deprecated, так как основной конструктор теперь может спокойно работать с N параметрами)
2) Добавил возможность подменять provider до api, так как веду два проекта, один кидает запросы сквозь прослойку очереди, а второй используя fasthttp, поэтому иногда необходимо иметь возможность подменять свой клиент, да и к тому же нужно иметь иногда возможность конфигурировать тот же http client иногда
3) Добавил CI, хотя бы простой линтер
4) Отрефакторил код, так как без этого было бы тяжело внести выше указанные изменения
5) Пришлось местами костылить и слегка говнокодить, дабы полностью сохранить обратную совместимость (пример из example не трогался вообще и продолжает работать)

Если зайдет, то могу в дальнейшем докинуть тестов, а также заняться sandbox и stream полноценно