### PR TITLE
updated REST API URL

### DIFF
--- a/rest_client.go
+++ b/rest_client.go
@@ -18,7 +18,7 @@ var (
 
 const (
 	// RestAPIURL contains main api url for tinkoff invest api.
-	RestAPIURL = "https://api-invest.tinkoff.ru/openapi"
+	RestAPIURL = "https://invest-public-api.tinkoff.ru/rest"
 	// MaxTimeout for provider request.
 	MaxTimeout = time.Second * 30
 )


### PR DESCRIPTION
Probably REST API URL a bit outdated and not accessible.
according https://github.com/Tinkoff/investAPI/ swagger pointed to https://invest-public-api.tinkoff.ru/rest.